### PR TITLE
Use object=? on objects instead of eq? to properly handle contracted obj...

### DIFF
--- a/snip-lib/racket/snip/private/snip.rkt
+++ b/snip-lib/racket/snip/private/snip.rkt
@@ -145,7 +145,10 @@
   (def/public (get-admin) s-admin)
 
   (def/public (set-admin [(make-or-false snip-admin%) a])
-    (unless (and (not (eq? a s-admin))
+    (unless (and (not (or (and (object? s-admin)
+                               (object? a)
+                               (object=? a s-admin))
+                          (eq? a s-admin)))
                  (has-flag? s-flags OWNED)
                  (or a 
                      (not (has-flag? s-flags CAN-DISOWN))))
@@ -211,7 +214,7 @@
     #f)
 
   (def/public (match? [snip% other])
-    (and (eq? s-snipclass (snip->snipclass other))
+    (and (object=? s-snipclass (snip->snipclass other))
          (= s-count (get-field s-count other))))
   
   (def/public (own-caret [any? own?])
@@ -326,7 +329,7 @@
   
   (def/public (equal-to? [snip% that] [any? recur]) 
     (send that other-equal-to? this recur))
-  (def/public (other-equal-to? [snip% that] [any? recur]) (eq? this that))
+  (def/public (other-equal-to? [snip% that] [any? recur]) (object=? this that))
   (define/public (equal-hash-code-of recur) (eq-hash-code this))
   (define/public (equal-secondary-hash-code-of recur) 1))
  
@@ -1265,7 +1268,8 @@
     (* i IMAGE-PIXELS-PER-SCROLL))
 
   (def/override (set-admin [(make-or-false snip-admin%) a])
-    (when (not (eq? a s-admin))
+    (when (not (or (and (object? a) (object? s-admin) (object=? a s-admin))
+                   (eq? a s-admin)))
       (super set-admin a))
     (when (and s-admin is-relative-path? filename)
       (load-file filename filetype #t))))


### PR DESCRIPTION
This pull requests changes several instances of `eq?` in the snip implementation to instead use `object=?` allowing for contracted objects to be compared, and improving interop with typed racket.