### PR TITLE
Add missing local member names for snips

### DIFF
--- a/snip-lib/racket/snip/private/private.rkt
+++ b/snip-lib/racket/snip/private/private.rkt
@@ -10,13 +10,13 @@
 
 ;; snip% and editor%
 (define-local-member-name
-  s-admin)
+  s-admin set-s-admin)
 
 ;; snip%
 (define-local-member-name
   s-prev set-s-prev
   s-next set-s-next
-  s-count
+  s-count set-s-count
   s-style set-s-style
   s-line set-s-line
   s-snipclass set-s-snipclass


### PR DESCRIPTION
I think these methods are supposed to be local, but they are currently publicly accessible. (discovered via contract problems in TR programs)