### PR TITLE
Update contract on image-snip% other-equal-to? method (racket/gui#119)

### DIFF
--- a/snip-lib/racket/snip/private/contract.rkt
+++ b/snip-lib/racket/snip/private/contract.rkt
@@ -456,7 +456,7 @@
     (load-file (->*m ((or/c path-string? input-port? #f))
                      (tab-snip-filetype/c any/c any/c)
                      void?))
-    (other-equal-to? (->m (is-a?/c image-snip%)
+    (other-equal-to? (->m (is-a?/c snip%)
                           (any/c any/c . -> . boolean?)
                           boolean?))
     (resize (->m (>=/c 0)

--- a/snip-lib/racket/snip/private/snip.rkt
+++ b/snip-lib/racket/snip/private/snip.rkt
@@ -1195,35 +1195,36 @@
   (def/public (get-bitmap-mask)
     mask)
 
-  (def/override (other-equal-to? [image-snip% other] [any? recur])
-    (let* ([bm (send this get-bitmap)]
-           [bm2 (send other get-bitmap)])
-      (and
-       bm (send bm ok?)
-       bm2 (send bm ok?)
-       (= (send bm get-depth) (send bm2 get-depth))
-       (let ([w (send bm get-width)]
-             [h (send bm get-height)])
-         (and
-          (= w (send bm2 get-width))
-          (= h (send bm2 get-height))
-          (let ([s1 (make-bytes (* w h 4))]
-                [s2 (make-bytes (* w h 4))])
-            (send bm get-argb-pixels 0 0 w h s1 #f)
-            (send bm2 get-argb-pixels 0 0 w h s2 #f)
-            (let ([mask (send this get-bitmap-mask)])
-              (when (and mask
-                         (send mask ok?)
-                         (= w (send mask get-width))
-                         (= h (send mask get-height)))
-                (send mask get-argb-pixels 0 0 w h s1 #t)))
-            (let ([mask2 (send other get-bitmap-mask)])
-              (when (and mask2
-                         (send mask2 ok?)
-                         (= w (send mask2 get-width))
-                         (= h (send mask2 get-height)))
-                (send mask2 get-argb-pixels 0 0 w h s2 #t)))
-            (equal? s1 s2)))))))
+  (def/override (other-equal-to? [snip% other] [any? recur])
+    (and (is-a? other this%)
+         (let* ([bm (send this get-bitmap)]
+                [bm2 (send other get-bitmap)])
+           (and
+            bm (send bm ok?)
+            bm2 (send bm ok?)
+            (= (send bm get-depth) (send bm2 get-depth))
+            (let ([w (send bm get-width)]
+                  [h (send bm get-height)])
+              (and
+               (= w (send bm2 get-width))
+               (= h (send bm2 get-height))
+               (let ([s1 (make-bytes (* w h 4))]
+                     [s2 (make-bytes (* w h 4))])
+                 (send bm get-argb-pixels 0 0 w h s1 #f)
+                 (send bm2 get-argb-pixels 0 0 w h s2 #f)
+                 (let ([mask (send this get-bitmap-mask)])
+                   (when (and mask
+                              (send mask ok?)
+                              (= w (send mask get-width))
+                              (= h (send mask get-height)))
+                     (send mask get-argb-pixels 0 0 w h s1 #t)))
+                 (let ([mask2 (send other get-bitmap-mask)])
+                   (when (and mask2
+                              (send mask2 ok?)
+                              (= w (send mask2 get-width))
+                              (= h (send mask2 get-height)))
+                     (send mask2 get-argb-pixels 0 0 w h s2 #t)))
+                 (equal? s1 s2))))))))
 
   (define/private (do-hash-code hash-code)
     (if (and bm 


### PR DESCRIPTION
The contract on the other-equal-to? method accepted only `image-snip%`
instances, which caused a contract violation when comparing an `image-snip%`
with another non-`image-snip%`, instead of returning #f.

I updated the contract to accept a `snip%` object instead (same contract as
the parent class) and check inside the method if the object is an
`image-snip%`

Here is a sample program to test the fix:

    #lang racket
    (require racket/gui pict pict/snip rackunit)
    (define s1 (make-object image-snip% (pict->bitmap (text "hello"))))
    (define s2 (make-object pict-snip% (text "hello")))
    (define s3 (make-object image-snip% (pict->bitmap (text "hello"))))

    (check-true (equal? s1 s1))
    (check-false (equal? s1 s2))
    (check-false (equal? s2 s1)) ; this case used to report a contract violation
    (check-true (equal? s1 s3))
    (check-true (equal? s3 s1))