### PR TITLE
fix a problem with potential hash modifications

### DIFF
--- a/snip-lib/info.rkt
+++ b/snip-lib/info.rkt
@@ -9,7 +9,7 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.5")
+(define version "1.6")
 
 (define license
   '(Apache-2.0 OR MIT))


### PR DESCRIPTION
specifically, collect all the callbacks to run before running any of them and then reset the table holding the callbacks. This way, we don't have any concurrent modification of the has and we also don't discard any style changes that may happen during the callbacks